### PR TITLE
docs: document usage and drop binary assets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# PostgreSQL
+db_host=postgres
+db_name=music_platform
+db_user=music
+db_password=music
+
+# Django
+secret_key=replace-this-secret-key
+allowed_hosts=localhost,127.0.0.1
+
+# Redis
+redis_url=redis://redis:6379/0
+
+# MinIO
+minio_endpoint=minio:9000
+minio_access_key=music
+minio_secret_key=musicsecret
+minio_bucket=media
+
+# Web
+next_public_api_url=http://localhost:8000
+
+# Mobile
+expo_public_api_url=http://10.0.2.2:8000
+
+# Local testing (optional)
+USE_SQLITE_FOR_TESTS=0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Python
+__pycache__/
+*.py[cod]
+*.sqlite3
+.env
+.venv/
+venv/
+*.log
+
+# Node
+node_modules/
+.npm/
+.next/
+.out/
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# Expo/React Native
+.expo/
+.expo-shared/
+web-build/
+android/
+ios/
+
+# Docker
+*.pid
+*.sock
+
+# Misc
+.DS_Store
+.idea/
+.vscode/
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: up down build backend-shell celery-shell tests
+
+up:
+docker compose up --build
+
+down:
+docker compose down
+
+build:
+docker compose build
+
+backend-shell:
+docker compose run --rm django /bin/bash
+
+celery-shell:
+docker compose run --rm celery /bin/bash
+
+tests:
+docker compose run --rm django python manage.py test

--- a/README.MD
+++ b/README.MD
@@ -131,3 +131,49 @@
 - 🔴 **高优先级**：M1 + M2 基础功能（闭环跑通必须）。  
 - 🟡 **中优先级**：M3、M4（增强体验，进入内测）。  
 - 🟢 **低优先级**：M5 及后续演进（长期优化）。  
+
+---
+
+## 快速开始（开发环境）
+
+本仓库已经按照任务 1.1 的要求，提供了一套基于 Docker Compose 的本地化开发环境：
+
+1. **准备环境**
+   - 安装 Docker 与 Docker Compose v2。
+   - 将 `.env.example` 复制为 `.env`，并根据实际情况填写密钥或域名。
+
+2. **启动所有服务**
+   ```bash
+   make up
+   ```
+   该命令会按需构建镜像并启动以下容器：Postgres、Redis、MinIO、Django、Celery Worker、Next.js Web、Expo Web（React Native Dev Server）。
+
+3. **服务访问入口**
+   - Django API：http://localhost:8000/api/health/
+   - Web 前端（Next.js）：http://localhost:3000
+   - React Native Web 端（Expo Dev Server）：http://localhost:19006
+   - MinIO 控制台：http://localhost:9001 （默认账号密码 `music` / `musicsecret`）
+
+4. **运行后端测试**
+   ```bash
+   make tests
+   ```
+   如果当前环境无法使用 Docker，可以先安装依赖后在本地使用 SQLite 运行测试：
+   ```bash
+   pip install -r backend/requirements.txt
+   USE_SQLITE_FOR_TESTS=1 python backend/manage.py test
+   ```
+
+5. **关闭环境**
+   ```bash
+   make down
+   ```
+
+如需进入容器执行命令，可使用 `make backend-shell` 或 `make celery-shell`。后续迭代可在现有目录结构下扩展各模块功能，逐步完成 README 中的全部里程碑。
+
+---
+
+## 文档与资源
+
+- [docs/USAGE.md](docs/USAGE.md)：提供详细的环境配置、启动、测试与前端开发说明。
+- `mobile/assets/README.md`：说明如何在不提交二进制文件的前提下自定义 Expo 图标与启动页，避免 PR 校验的「Binary files are not supported」提示。

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+COPY . .
+
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core application for common utilities and health checks."""

--- a/backend/core/apps.py
+++ b/backend/core/apps.py
@@ -1,0 +1,11 @@
+"""App configuration for the core Django app."""
+from __future__ import annotations
+
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    """Configuration for the core app."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -1,0 +1,10 @@
+"""Celery tasks for the core app."""
+from __future__ import annotations
+
+from celery import shared_task
+
+
+@shared_task
+def ping() -> str:
+    """Simple task used to verify Celery workers are running."""
+    return "pong"

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,0 +1,14 @@
+"""Tests for the core app."""
+from __future__ import annotations
+
+from django.test import TestCase
+from django.urls import reverse
+
+
+class HealthEndpointTests(TestCase):
+    """Basic tests covering the health endpoint."""
+
+    def test_health_endpoint_returns_ok_status(self) -> None:
+        response = self.client.get(reverse("api-health"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,0 +1,10 @@
+"""URL routing for the core app."""
+from __future__ import annotations
+
+from django.urls import path
+
+from .views import HealthCheckView
+
+urlpatterns = [
+    path("health/", HealthCheckView.as_view(), name="api-health"),
+]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,0 +1,29 @@
+"""Views for the core app."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from django.conf import settings
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class HealthCheckView(APIView):
+    """Simple API view to ensure the stack is operational."""
+
+    authentication_classes: list = []
+    permission_classes: list = []
+
+    def get(self, request, *args, **kwargs):  # type: ignore[override]
+        return Response(
+            {
+                "status": "ok",
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+                "environment": {
+                    "debug": settings.DEBUG,
+                    "database": settings.DATABASES["default"]["HOST"],
+                    "redis": settings.CELERY_BROKER_URL,
+                    "minio": settings.MINIO_ENDPOINT,
+                },
+            }
+        )

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+python manage.py migrate --noinput
+
+exec "$@"

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main() -> None:
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "music_platform.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/music_platform/__init__.py
+++ b/backend/music_platform/__init__.py
@@ -1,0 +1,6 @@
+"""Music platform Django project initialization."""
+from __future__ import annotations
+
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/backend/music_platform/asgi.py
+++ b/backend/music_platform/asgi.py
@@ -1,0 +1,10 @@
+"""ASGI config for music platform project."""
+from __future__ import annotations
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "music_platform.settings")
+
+application = get_asgi_application()

--- a/backend/music_platform/celery.py
+++ b/backend/music_platform/celery.py
@@ -1,0 +1,18 @@
+"""Celery application for the music platform."""
+from __future__ import annotations
+
+import os
+
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "music_platform.settings")
+
+app = Celery("music_platform")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self) -> str:
+    """Default debug task to verify Celery configuration."""
+    return f"Request: {self.request!r}"

--- a/backend/music_platform/settings.py
+++ b/backend/music_platform/settings.py
@@ -1,0 +1,142 @@
+"""Django settings for the music platform project."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = os.environ.get("SECRET_KEY", "unsafe-secret-key")
+DEBUG = os.environ.get("DEBUG", "1") == "1"
+ALLOWED_HOSTS = [host.strip() for host in os.environ.get("allowed_hosts", "*").split(",") if host.strip()]
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "corsheaders",
+    "rest_framework",
+    "core",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "music_platform.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]
+
+WSGI_APPLICATION = "music_platform.wsgi.application"
+ASGI_APPLICATION = "music_platform.asgi.application"
+
+if os.environ.get("USE_SQLITE_FOR_TESTS", "0") == "1":
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.environ.get("POSTGRES_DB", "music_platform"),
+            "USER": os.environ.get("POSTGRES_USER", "music"),
+            "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "music"),
+            "HOST": os.environ.get("POSTGRES_HOST", "postgres"),
+            "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+        }
+    }
+
+AUTH_PASSWORD_VALIDATORS = [
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+]
+
+LANGUAGE_CODE = "zh-hans"
+TIME_ZONE = "Asia/Shanghai"
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+STATICFILES_DIRS = [BASE_DIR / "static"]
+
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.BasicAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.AllowAny",
+    ],
+}
+
+CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOW_CREDENTIALS = True
+
+CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+CELERY_ACCEPT_CONTENT = ["json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_SERIALIZER = "json"
+CELERY_TIMEZONE = TIME_ZONE
+
+MINIO_ENDPOINT = os.environ.get("MINIO_ENDPOINT", "minio:9000")
+MINIO_ACCESS_KEY = os.environ.get("MINIO_ACCESS_KEY", "music")
+MINIO_SECRET_KEY = os.environ.get("MINIO_SECRET_KEY", "musicsecret")
+MINIO_BUCKET_NAME = os.environ.get("MINIO_BUCKET_NAME", "media")
+MINIO_USE_SSL = os.environ.get("MINIO_USE_SSL", "0") == "1"
+
+NEXT_PUBLIC_API_URL = os.environ.get("NEXT_PUBLIC_API_URL", "http://localhost:8000")
+EXPO_PUBLIC_API_URL = os.environ.get("EXPO_PUBLIC_API_URL", "http://10.0.2.2:8000")
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",
+    },
+}

--- a/backend/music_platform/urls.py
+++ b/backend/music_platform/urls.py
@@ -1,0 +1,10 @@
+"""URL configuration for the music platform project."""
+from __future__ import annotations
+
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/", include("core.urls")),
+]

--- a/backend/music_platform/wsgi.py
+++ b/backend/music_platform/wsgi.py
@@ -1,0 +1,10 @@
+"""WSGI config for music platform project."""
+from __future__ import annotations
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "music_platform.settings")
+
+application = get_wsgi_application()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+Django==4.2.7
+djangorestframework==3.14.0
+django-cors-headers==3.13.0
+psycopg2-binary==2.9.7
+celery==5.3.4
+redis==5.0.1
+boto3==1.28.57
+minio==7.1.16
+python-dotenv==1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,110 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: music
+      POSTGRES_PASSWORD: music
+      POSTGRES_DB: music_platform
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+
+  minio:
+    image: minio/minio:RELEASE.2023-08-16T20-17-30Z
+    restart: unless-stopped
+    environment:
+      MINIO_ROOT_USER: music
+      MINIO_ROOT_PASSWORD: musicsecret
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  django:
+    build:
+      context: ./backend
+    depends_on:
+      - postgres
+      - redis
+      - minio
+    environment:
+      DJANGO_SETTINGS_MODULE: music_platform.settings
+      SECRET_KEY: ${secret_key:-replace-this-secret-key}
+      POSTGRES_DB: ${db_name:-music_platform}
+      POSTGRES_USER: ${db_user:-music}
+      POSTGRES_PASSWORD: ${db_password:-music}
+      POSTGRES_HOST: ${db_host:-postgres}
+      POSTGRES_PORT: 5432
+      REDIS_URL: ${redis_url:-redis://redis:6379/0}
+      MINIO_ENDPOINT: ${minio_endpoint:-minio:9000}
+      MINIO_ACCESS_KEY: ${minio_access_key:-music}
+      MINIO_SECRET_KEY: ${minio_secret_key:-musicsecret}
+      MINIO_BUCKET_NAME: ${minio_bucket:-media}
+      NEXT_PUBLIC_API_URL: ${next_public_api_url:-http://localhost:8000}
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+
+  celery:
+    build:
+      context: ./backend
+    depends_on:
+      - django
+      - redis
+    environment:
+      DJANGO_SETTINGS_MODULE: music_platform.settings
+      SECRET_KEY: ${secret_key:-replace-this-secret-key}
+      POSTGRES_DB: ${db_name:-music_platform}
+      POSTGRES_USER: ${db_user:-music}
+      POSTGRES_PASSWORD: ${db_password:-music}
+      POSTGRES_HOST: ${db_host:-postgres}
+      POSTGRES_PORT: 5432
+      REDIS_URL: ${redis_url:-redis://redis:6379/0}
+      MINIO_ENDPOINT: ${minio_endpoint:-minio:9000}
+      MINIO_ACCESS_KEY: ${minio_access_key:-music}
+      MINIO_SECRET_KEY: ${minio_secret_key:-musicsecret}
+      MINIO_BUCKET_NAME: ${minio_bucket:-media}
+    command: celery -A music_platform worker -l info
+    volumes:
+      - ./backend:/app
+
+  web:
+    build:
+      context: ./web
+    depends_on:
+      - django
+    environment:
+      NEXT_PUBLIC_API_URL: ${next_public_api_url:-http://localhost:8000}
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./web:/app
+
+  mobile:
+    build:
+      context: ./mobile
+    depends_on:
+      - django
+    environment:
+      EXPO_PUBLIC_API_URL: ${expo_public_api_url:-http://10.0.2.2:8000}
+    ports:
+      - "19006:19006"
+    volumes:
+      - ./mobile:/app
+
+volumes:
+  postgres_data:
+  minio_data:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,123 @@
+# Music Platform Monorepo – Usage Guide
+
+This document explains how to bootstrap the development environment, run the available services, and execute automated tests for the self-hosted music platform stack.
+
+## Repository Layout
+
+```
+backend/   # Django + Celery application and project configuration
+mobile/    # Expo (React Native) client for iOS, Android, and web preview
+web/       # Next.js web client
+```
+
+Supporting files include:
+
+- `docker-compose.yml` – service orchestration for databases, storage, backend, and frontends.
+- `Makefile` – convenience wrappers around common `docker compose` commands.
+- `.env.example` – template of required environment variables.
+
+## Prerequisites
+
+- Docker Engine 24+ and Docker Compose v2 (recommended for the full stack).
+- Node.js 18+ and Yarn/NPM if you prefer to run web/mobile clients without Docker.
+- Python 3.11+ if you need to execute the Django backend directly.
+
+## Environment Setup
+
+1. Duplicate the example environment file:
+   ```bash
+   cp .env.example .env
+   ```
+2. Adjust any secrets, passwords, or hostnames to fit your local environment. The defaults are suitable for a single-machine developer setup.
+
+## Starting the Full Stack with Docker
+
+Use the provided Make target to build images and launch every service:
+
+```bash
+make up
+```
+
+The following endpoints will become available once the containers finish booting:
+
+- Django API (health check): <http://localhost:8000/api/health/>
+- Next.js web client: <http://localhost:3000>
+- Expo web preview: <http://localhost:19006>
+- MinIO console: <http://localhost:9001> (credentials `music` / `musicsecret`)
+
+You can open a shell inside running containers:
+
+```bash
+make backend-shell   # Attach to the Django container
+make celery-shell    # Attach to the Celery worker
+```
+
+To stop and remove all containers, networks, and volumes created by Compose:
+
+```bash
+make down
+```
+
+## Running Without Docker (SQLite Fallback)
+
+If Docker is unavailable, you can still run the Django test suite locally using SQLite:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+USE_SQLITE_FOR_TESTS=1 python backend/manage.py migrate
+USE_SQLITE_FOR_TESTS=1 python backend/manage.py test
+```
+
+The `USE_SQLITE_FOR_TESTS` environment variable triggers a lightweight in-memory database configuration defined in `backend/music_platform/settings.py`.
+
+## Testing Shortcut
+
+A convenient Make target wraps the Django test command (runs within Docker when available):
+
+```bash
+make tests
+```
+
+## Frontend Development Notes
+
+### Next.js Web
+
+Install dependencies and run the development server without Docker:
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+The web client reads the API base URL from `NEXT_PUBLIC_API_BASE_URL` (defined in `.env` and injected via Docker Compose for containerised runs).
+
+### Expo Mobile
+
+This repository intentionally **omits binary image assets** (icons and splash screens) to avoid issues with environments that disallow binary files. Expo falls back to default visuals when these assets are absent.
+
+To customise them:
+
+1. Place your PNG files inside `mobile/assets/`.
+2. Update `mobile/app.json` with the filenames (see `mobile/assets/README.md`).
+3. Restart the Expo development server or rebuild the project.
+
+Launch Expo locally with:
+
+```bash
+cd mobile
+npm install
+npm run start
+```
+
+## Troubleshooting
+
+- **Binary file errors when creating PRs** – ensure no binary artefacts are tracked by Git. The repository keeps only text-based placeholders for assets; add your own binaries locally without committing them.
+- **Docker unavailable** – use the SQLite fallback commands above.
+- **Port conflicts** – stop any existing services listening on the ports listed in the Docker section or edit `docker-compose.yml` to remap ports.
+
+## Next Steps
+
+The README (`README.MD`) outlines the broader project milestones. Extend the backend and frontend applications iteratively to satisfy those milestones once the environment is confirmed working.

--- a/mobile/.dockerignore
+++ b/mobile/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.expo
+web-build

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,71 @@
+import { StatusBar } from 'expo-status-bar';
+import React from 'react';
+import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+
+const modules = [
+  '用户登录与权限',
+  '曲库上传与转码',
+  '播放记录与推荐'
+];
+
+export default function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>音乐平台移动端</Text>
+        <Text style={styles.subtitle}>Expo 驱动的开发环境已经就绪。</Text>
+        {modules.map((module) => (
+          <View key={module} style={styles.card}>
+            <Text style={styles.cardText}>{module}</Text>
+          </View>
+        ))}
+        <Text style={styles.note}>API: {process.env.EXPO_PUBLIC_API_URL}</Text>
+      </View>
+      <StatusBar style="light" />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f172a',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  content: {
+    width: '90%',
+    maxWidth: 480,
+    alignItems: 'center'
+  },
+  title: {
+    fontSize: 28,
+    color: '#e2e8f0',
+    fontWeight: 'bold',
+    marginBottom: 12
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#94a3b8',
+    textAlign: 'center',
+    marginBottom: 24
+  },
+  card: {
+    width: '100%',
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: 'rgba(30, 41, 59, 0.8)',
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(148, 163, 184, 0.3)'
+  },
+  cardText: {
+    color: '#cbd5f5',
+    fontSize: 16,
+    textAlign: 'center'
+  },
+  note: {
+    marginTop: 16,
+    color: '#cbd5f5'
+  }
+});

--- a/mobile/Dockerfile
+++ b/mobile/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-bullseye
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 19006
+
+CMD ["npm", "run", "start"]

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,18 @@
+{
+  "expo": {
+    "name": "MusicPlatform",
+    "slug": "music-platform",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "jsEngine": "hermes",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "backgroundColor": "#0f172a"
+    },
+    "platforms": ["ios", "android", "web"],
+    "web": {
+      "bundler": "metro",
+      "output": "static"
+    }
+  }
+}

--- a/mobile/assets/README.md
+++ b/mobile/assets/README.md
@@ -1,0 +1,23 @@
+# Customising Expo Assets
+
+This directory intentionally stores only documentation so that the repository avoids bundling binary image files, which are not supported by the target submission system.
+
+To personalise the Expo application icon or splash screen:
+
+1. Add your PNG assets (recommended square icon at 1024×1024 and splash image at 2048×2048) into this folder.
+2. Update `app.json` to point to your filenames. For example:
+   ```json
+   {
+     "expo": {
+       "icon": "./assets/icon.png",
+       "splash": {
+         "image": "./assets/splash.png",
+         "resizeMode": "contain",
+         "backgroundColor": "#0f172a"
+       }
+     }
+   }
+   ```
+3. Rebuild or restart the Expo development server so the new assets are picked up.
+
+If you skip these steps, Expo will use its default icon and splash visuals, which is sufficient for development and automated testing.

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo']
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "music-platform-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start --web --non-interactive --port 19006",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~49.0.13",
+    "expo-status-bar": "~1.6.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.72.6",
+    "react-native-web": "~0.19.6"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  }
+}

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.next
+out

--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-bullseye
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+  }
+};
+
+module.exports = nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "music-platform-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.5.9",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.49.0",
+    "eslint-config-next": "13.5.6",
+    "typescript": "5.2.2"
+  }
+}

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,0 +1,16 @@
+import type { AppProps } from 'next/app';
+import Head from 'next/head';
+
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Head>
+        <title>自建音乐平台</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,0 +1,50 @@
+import Head from 'next/head';
+import styles from '../styles/Home.module.css';
+
+const modules = [
+  {
+    title: '后端服务',
+    description: 'Django + Celery + MinIO 构成的本地化音频处理后端。'
+  },
+  {
+    title: 'Web 前端',
+    description: 'Next.js 播放器，集成登录、搜索与推荐等功能。'
+  },
+  {
+    title: '移动端',
+    description: 'React Native (Expo) 客户端支持后台播放与离线缓存。'
+  }
+];
+
+export default function Home() {
+  return (
+    <div className={styles.container}>
+      <Head>
+        <title>音乐平台任务看板</title>
+        <meta name="description" content="Self-hosted 音乐平台全栈架构" />
+      </Head>
+
+      <main className={styles.main}>
+        <h1 className={styles.title}>音乐平台任务总览</h1>
+        <p className={styles.subtitle}>
+          使用 docker-compose 一键启动的全栈开发环境，覆盖 README 中的核心模块。
+        </p>
+
+        <div className={styles.grid}>
+          {modules.map((module) => (
+            <div key={module.title} className={styles.card}>
+              <h2>{module.title}</h2>
+              <p>{module.description}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.note}>
+          <p>
+            后端 API 地址：<code>{process.env.NEXT_PUBLIC_API_URL}</code>
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/web/styles/Home.module.css
+++ b/web/styles/Home.module.css
@@ -1,0 +1,67 @@
+.container {
+  min-height: 100vh;
+  padding: 4rem 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.main {
+  max-width: 960px;
+  width: 100%;
+}
+
+.title {
+  font-size: 3rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.subtitle {
+  text-align: center;
+  margin-bottom: 3rem;
+  color: #94a3b8;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 25px -15px rgba(15, 23, 42, 0.8);
+}
+
+.card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+}
+
+.card p {
+  margin: 0;
+  color: #cbd5f5;
+}
+
+.note {
+  margin-top: 3rem;
+  text-align: center;
+  color: #cbd5f5;
+}
+
+.note code {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -1,0 +1,18 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- remove Expo icon and splash binaries and replace them with text guidance to avoid PR upload issues
- document end-to-end usage instructions for Docker, SQLite fallback, and frontend workflows in docs/USAGE.md
- cross-link the new documentation from the main README so contributors can discover it easily

## Testing
- `python -m compileall backend`


------
https://chatgpt.com/codex/tasks/task_e_68d299f91e6c8322bb8f300852c3c648