### PR TITLE
Add service overview endpoint and fix tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 .PHONY: up down build backend-shell celery-shell tests
 
 up:
-docker compose up --build
+	docker compose up --build
 
 down:
-docker compose down
+	docker compose down
 
 build:
-docker compose build
+	docker compose build
 
 backend-shell:
-docker compose run --rm django /bin/bash
+	docker compose run --rm django /bin/bash
 
 celery-shell:
-docker compose run --rm celery /bin/bash
+	docker compose run --rm celery /bin/bash
 
 tests:
-docker compose run --rm django python manage.py test
+	docker compose run --rm django python manage.py test

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -5,10 +5,32 @@ from django.test import TestCase
 from django.urls import reverse
 
 
-class HealthEndpointTests(TestCase):
+class TestHealthEndpoint(TestCase):
     """Basic tests covering the health endpoint."""
 
     def test_health_endpoint_returns_ok_status(self) -> None:
         response = self.client.get(reverse("api-health"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "ok")
+
+
+class TestServiceOverview(TestCase):
+    """Ensure the landing page renders useful metadata."""
+
+    def test_root_path_returns_overview_payload(self) -> None:
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.json()
+        self.assertEqual(payload["service"], "Music Platform API")
+        self.assertIn("links", payload)
+        self.assertIn("api_root", payload["links"])
+        self.assertIn("health", payload["links"])
+
+    def test_api_root_matches_top_level_response(self) -> None:
+        top_level_response = self.client.get("/")
+        self.assertEqual(top_level_response.status_code, 200)
+
+        api_root_response = self.client.get(reverse("api-root"))
+        self.assertEqual(api_root_response.status_code, 200)
+        self.assertEqual(api_root_response.json(), top_level_response.json())

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 from django.urls import path
 
-from .views import HealthCheckView
+from .views import HealthCheckView, ServiceOverviewView
 
 urlpatterns = [
+    path("", ServiceOverviewView.as_view(), name="api-root"),
     path("health/", HealthCheckView.as_view(), name="api-health"),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from datetime import datetime
 
 from django.conf import settings
+from django.urls import reverse
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -24,6 +26,30 @@ class HealthCheckView(APIView):
                     "database": settings.DATABASES["default"]["HOST"],
                     "redis": settings.CELERY_BROKER_URL,
                     "minio": settings.MINIO_ENDPOINT,
+                },
+            }
+        )
+
+
+class ServiceOverviewView(APIView):
+    """Provide a small JSON landing page for the service."""
+
+    authentication_classes: list = []
+    permission_classes: list = []
+
+    def get(self, request: Request, *args, **kwargs):  # type: ignore[override]
+        health_url = request.build_absolute_uri(reverse("api-health"))
+        api_root_url = request.build_absolute_uri(reverse("api-root"))
+        admin_url = request.build_absolute_uri(reverse("admin:index"))
+
+        return Response(
+            {
+                "service": "Music Platform API",
+                "message": "Welcome to the self-hosted music platform backend.",
+                "links": {
+                    "api_root": api_root_url,
+                    "health": health_url,
+                    "admin": admin_url,
                 },
             }
         )

--- a/backend/music_platform/urls.py
+++ b/backend/music_platform/urls.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from django.contrib import admin
 from django.urls import include, path
 
+from core.views import ServiceOverviewView
+
 urlpatterns = [
+    path("", ServiceOverviewView.as_view(), name="service-overview"),
     path("admin/", admin.site.urls),
     path("api/", include("core.urls")),
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres:
     image: postgres:15


### PR DESCRIPTION
## Summary
- add a JSON service overview endpoint that serves the project root and /api/
- expose the overview via URL routing and cover it with tests
- repair helper tooling by fixing the Makefile tabbing and removing the obsolete docker compose version key

## Testing
- USE_SQLITE_FOR_TESTS=1 python backend/manage.py test core

------
https://chatgpt.com/codex/tasks/task_e_68d3deca80548322a1628eaa3e9bc56f