### PR TITLE
Fix frontend container node_modules volume configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       - "3000:3000"
     volumes:
       - ./web:/app
+      - /app/node_modules
 
   mobile:
     build:
@@ -102,6 +103,7 @@ services:
       - "19006:19006"
     volumes:
       - ./mobile:/app
+      - /app/node_modules
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- ensure the web and mobile docker compose services mount an anonymous /app/node_modules volume so dependencies installed during build are preserved at runtime

## Testing
- docker compose config *(fails: docker not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d49fd0069083229d9948d1a5983f64