### PR TITLE
Add TB figure data-source mapping and reproduction guide

### DIFF
--- a/analysis/tb_repro/README.md
+++ b/analysis/tb_repro/README.md
@@ -1,0 +1,49 @@
+# Figure source + reproduction guide (TB chemokine panel)
+
+This guide maps the uploaded figure to its data sources and provides a reproducible workflow.
+
+## Figure match
+The image matches **Figure 4** ("Myeloid–T cell chemokine interactions dominate lungs of C57BL/6 mice...") from:
+
+- Branchett *et al.* (2025), *Journal of Experimental Medicine*.
+- Article page: https://rupress.org/jem/article/222/12/e20250466/278334/Type-I-IFN-drives-neutrophil-swarming-impeding
+
+## Primary data sources
+### 1) Bulk RNA-seq (panel c)
+- GEO series: **GSE298786**
+- Lung normalized expression table used for panel-c-like plot:
+  - `GSE298786_202501_lung_norm_expr.csv.gz`
+- GEO record: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE298786
+
+### 2) scRNA-seq (panels a, b, d)
+- GEO series: **GSE298787**
+- Files:
+  - `GSE298787_cellranger_outs.tar.gz`
+  - `GSE298787_sc_integrated.rdata.gz`
+- GEO record: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE298787
+
+### 3) Analysis code
+- GitHub repository from paper Data Availability section:
+  - https://github.com/willjbranchett/branchett_et_al_tb
+
+## Minimal reproduction commands (run in an internet-enabled environment)
+
+```bash
+# 0) clone analysis repo
+git clone https://github.com/willjbranchett/branchett_et_al_tb.git
+cd branchett_et_al_tb
+
+# 1) download bulk lung table (panel c source)
+curl -L -o GSE298786_202501_lung_norm_expr.csv.gz \
+  'https://ftp.ncbi.nlm.nih.gov/geo/series/GSE298nnn/GSE298786/suppl/GSE298786_202501_lung_norm_expr.csv.gz'
+
+# 2) optional: scRNA objects (for CellChat/dot/chord plots in panels a,b,d)
+curl -L -o GSE298787_sc_integrated.rdata.gz \
+  'https://ftp.ncbi.nlm.nih.gov/geo/series/GSE298nnn/GSE298787/suppl/GSE298787_sc_integrated.rdata.gz'
+
+# 3) follow repository scripts to rerun CellChat and plotting workflows
+#    (see repo README / scripts for figure-specific targets)
+```
+
+## Environment note
+This workspace blocks outbound package/data downloads from shell (proxy 403), so raw data retrieval and full rerun are documented but cannot be executed end-to-end here.


### PR DESCRIPTION
### Motivation

- Provide a clear mapping from the uploaded image to the original paper figure and the raw/processed data needed to reproduce it. 
- Collect the exact dataset accessions and author analysis code so users can rerun the analysis in an internet-enabled environment.

### Description

- Add `analysis/tb_repro/README.md` that identifies the figure as Figure 4 from Branchett et al. (JEM 2025) and links the article. 
- Record primary data sources `GSE298786` (bulk RNA-seq, `GSE298786_202501_lung_norm_expr.csv.gz`) and `GSE298787` (scRNA-seq, `cellranger_outs` and `sc_integrated.rdata`).
- Include the analysis code repository link `https://github.com/willjbranchett/branchett_et_al_tb` and a minimal set of shell commands to download the required files and rerun the plotting/CellChat workflows. 
- Note the environment limitation that outbound downloads are blocked by a proxy (403), so full end-to-end execution was documented but not performed in this container.

### Testing

- File content and presence were inspected successfully using a file listing and `nl` to print `analysis/tb_repro/README.md`.
- Attempts to download the GEO supplemental files with `curl` and `wget` failed due to a proxy `403` response, so data download was not completed here.
- Attempts to import plotting/data libraries in Python (e.g., `pandas`, `matplotlib`) failed because the packages were not installed and `pip install` was blocked by the proxy, so local execution was not possible in this environment.
- Repository state and file placement were verified and the new `analysis/tb_repro/README.md` is present in the project tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24860f43483228799063b93cd130b)